### PR TITLE
HPO-3160 Add support for products C4ls, Keno, Mmls and Uspbls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val commonDependencies = Seq(
   "org.bouncycastle" % "bcpkix-jdk15on" % versions("bouncycastle"),
   "org.bouncycastle" % "bcprov-jdk15on" % versions("bouncycastle"),
   "com.typesafe.play" % "play-json_2.11" % "2.4.6",
+  "com.beachape" %% "enumeratum" % "1.5.12",
   // test dependencies follow
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "junit" % "junit" % "4.10" % "test"

--- a/src/main/scala/domain/products/GamingProduct.scala
+++ b/src/main/scala/domain/products/GamingProduct.scala
@@ -1,11 +1,14 @@
 package domain.products
 
+import enumeratum.Enum
+import enumeratum.EnumEntry
 import java.net.URI
 
 import domain.products.GamingProduct.GamingProductId
 
+import scala.collection.immutable
 
-sealed trait ML24GamingProduct extends GamingProduct
+sealed trait ML24GamingProduct extends GamingProduct with EnumEntry
 
 
 trait GamingProduct {
@@ -17,7 +20,7 @@ trait GamingProduct {
 }
 
 
-object GamingProduct{
+object GamingProduct {
 
   final type GamingProductId = String
 
@@ -35,7 +38,7 @@ object GamingProduct{
 }
 
 
-object ML24GamingProduct {
+object ML24GamingProduct extends Enum[ML24GamingProduct] {
 
   object EJS extends ML24GamingProduct {
 
@@ -180,7 +183,28 @@ object ML24GamingProduct {
     override val lottery: PrimaryLottery = PrimaryLottery.Plus5
   }
 
-  val All = Vector[ML24GamingProduct](EJS, GLS, S6, S77, EMS, EMSPLUS, GLSS, IRLS, IRLSP1, IRLSP2, IRISHRAFFLE, UKLS, AOLS, APLS, ASLS, AMLS, AWLS, SLS,
-              UKTBLS, FLS, PLS, XMASL, PLUS5)
+  object KENO extends ML24GamingProduct {
+    override val id: GamingProductId = "keno"
+    override val lottery: PrimaryLottery = PrimaryLottery.Keno
+  }
+
+  object C4LS extends ML24GamingProduct {
+    override val id: GamingProductId = "c4ls"
+    override val lottery: PrimaryLottery = PrimaryLottery.Cash4Life
+  }
+
+  object USPBLS extends ML24GamingProduct {
+    override val id: GamingProductId = "uspbls"
+    override val lottery: PrimaryLottery = PrimaryLottery.UsPowerball
+  }
+
+  object MMLS extends ML24GamingProduct {
+    override val id: GamingProductId = "mmls"
+    override val lottery: PrimaryLottery = PrimaryLottery.MegaMillions
+  }
+
+  override lazy val values: immutable.IndexedSeq[ML24GamingProduct] = findValues
+  
+  val knownProductIds: Set[GamingProductId] = values.map(_.id).toSet
 
 }

--- a/src/main/scala/domain/products/PrimaryLottery.scala
+++ b/src/main/scala/domain/products/PrimaryLottery.scala
@@ -1,46 +1,24 @@
 package domain.products
 
+
 import java.util.Locale
+
+import enumeratum.{Enum, EnumEntry}
+
+import scala.collection.immutable
 
 /**
   * http://www.lotteries.io/concepts/draw-series
   */
-sealed trait PrimaryLottery extends Serializable {
+sealed trait PrimaryLottery extends Serializable with EnumEntry {
   def id: String
 }
 
-object PrimaryLottery {
+object PrimaryLottery extends Enum[PrimaryLottery] {
 
-  val allLotteries: Vector[PrimaryLottery] = {
-    Vector(
-      `6aus49`,
-      Spiel77,
-      Super6,
-      Glücksspirale,
-      Eurojackpot,
-      Euromillions,
-      EuromillionsPlus,
-      IrishLotto,
-      IrishLottoPlus1,
-      IrishLottoPlus2,
-      IrishRaffle,
-      UkLotto,
-      AUSOzLotto,
-      AUSPowerball,
-      AUSSaturdayLotto,
-      AUSMondayLotto,
-      AUSWednesdayLotto,
-      SwedishLotto,
-      FrenchLotto,
-      PolishLotto,
-      Keno,
-      Plus5,
-      Xmasl,
-      UkThunderball
-    )
-  }
+  override lazy val values: immutable.IndexedSeq[PrimaryLottery] = findValues
 
-  val allLotteriesById: Map[String, PrimaryLottery] = allLotteries.map(l => l.id -> l).toMap
+  val allLotteriesById: Map[String, PrimaryLottery] = values.map(l => l.id -> l).toMap
 
   def getLottery(id: String): Option[PrimaryLottery] = allLotteriesById.get(id)
 
@@ -162,6 +140,21 @@ object PrimaryLottery {
 
   case object IrishRaffle extends PrimaryLottery {
     val Name = "irishraffle"
+    override def id: String = Name
+  }
+  
+  case object Cash4Life extends PrimaryLottery {
+    val Name = "cash4life"
+    override def id: String = Name
+  }
+  
+  case object UsPowerball extends PrimaryLottery {
+    val Name = "uspowerball"
+    override def id: String = Name
+  }
+  
+  case object MegaMillions extends PrimaryLottery {
+    val Name = "megamillions"
     override def id: String = Name
   }
 

--- a/src/main/scala/domain/products/c4ls/C4lsGamingProductOrder.scala
+++ b/src/main/scala/domain/products/c4ls/C4lsGamingProductOrder.scala
@@ -1,0 +1,47 @@
+package domain.products.c4ls
+
+import java.net.URI
+import java.time.{DayOfWeek, LocalDate}
+
+import domain.products.GamingProduct.gamingProductIdToURI
+import domain.products.ML24GamingProduct.C4LS
+import domain.products.ParticipationPools.{ParticipationPoolId, formatParticipationPoolId}
+import domain.products.{Bet, GamingProductOrder, ParticipationPools}
+import play.api.libs.json.JsObject
+
+import scala.collection.breakOut
+
+
+case class C4lsGamingProductOrder(
+  bets: Seq[C4lsBet],
+  participationPools: C4lsParticipationPools,
+  variant: Option[String] = None,
+  json: JsObject
+) extends GamingProductOrder {
+  override def productURI: URI = C4lsGamingProductOrder.productURI
+
+  override def withEmptyJson(): C4lsGamingProductOrder = copy(json = JsObject(Seq.empty))
+}
+
+object C4lsGamingProductOrder {
+  val productURI: URI = gamingProductIdToURI(C4LS.id)
+}
+
+case class C4lsBet(numbers: Seq[Int], cashBall: Int) extends Bet
+
+case class C4lsParticipationPools(
+  firstDate: LocalDate,
+  drawDays: Set[DayOfWeek],
+  drawCount: Int
+) extends ParticipationPools {
+
+  def drawDates: Seq[LocalDate] = {
+    Iterator.iterate(firstDate)(_.plusDays(1))
+      .filter(drawDate => drawDays(drawDate.getDayOfWeek))
+      .take(drawCount)
+      .toVector
+  }
+
+  override def ids: Set[ParticipationPoolId] = drawDates.map(formatParticipationPoolId(C4LS.id, _))(breakOut)
+
+}

--- a/src/main/scala/domain/products/c4ls/C4lsProductOrderFactory.scala
+++ b/src/main/scala/domain/products/c4ls/C4lsProductOrderFactory.scala
@@ -1,0 +1,20 @@
+package domain.products.c4ls
+
+import domain.PoolResourceProvider.ProductOrderFactoryAI
+import play.api.libs.json.JsObject
+
+class C4lsProductOrderFactory extends ProductOrderFactoryAI[C4lsBet, C4lsParticipationPools, C4lsGamingProductOrder]{
+
+  protected def parseBets(bets: Seq[JsObject]): Seq[C4lsBet] = bets.map { bet => C4lsBet(
+    numbers = (bet \ "numbers").as[Seq[Int]], cashBall = (bet \ "cash-ball").as[Int]
+  )}
+
+  protected def parseParticipationPools(pools: JsObject): C4lsParticipationPools = fromIntermediateMultiDayPoolsData(pools) { data =>
+    C4lsParticipationPools(data.firstDate, data.drawDays, data.drawCount)
+  }
+
+  override protected def createOrder(bets: Seq[C4lsBet], pools: C4lsParticipationPools, variant: Option[String], json: JsObject): C4lsGamingProductOrder = {
+    C4lsGamingProductOrder(bets, pools, variant, json)
+  }
+
+}

--- a/src/main/scala/domain/products/keno/KenoGamingProductOrder.scala
+++ b/src/main/scala/domain/products/keno/KenoGamingProductOrder.scala
@@ -1,0 +1,45 @@
+package domain.products.keno
+
+import java.net.URI
+import java.time.LocalDate
+
+import domain.products.GamingProduct.gamingProductIdToURI
+import domain.products.ML24GamingProduct.KENO
+import domain.products.ParticipationPools.{ParticipationPoolId, formatParticipationPoolId}
+import domain.products.{Bet, GamingProductOrder, ParticipationPools}
+import play.api.libs.json.JsObject
+
+import scala.collection.breakOut
+
+
+case class KenoGamingProductOrder(
+  bets: Seq[KenoBet],
+  participationPools: KenoParticipationPools,
+  variant: Option[String] = None,
+  json: JsObject
+) extends GamingProductOrder {
+  override def productURI: URI = KenoGamingProductOrder.productURI
+
+  override def withEmptyJson(): KenoGamingProductOrder = copy(json = JsObject(Seq.empty))
+}
+
+object KenoGamingProductOrder {
+  val productURI: URI = gamingProductIdToURI(KENO.id)
+}
+
+case class KenoBet(numbers: Seq[Int], stake: Int) extends Bet
+
+case class KenoParticipationPools(
+  firstDate: LocalDate,
+  drawCount: Int
+) extends ParticipationPools {
+
+  def drawDates: Seq[LocalDate] = {
+    Iterator.iterate(firstDate)(_.plusDays(1))
+      .take(drawCount)
+      .toVector
+  }
+
+  override def ids: Set[ParticipationPoolId] = drawDates.map(formatParticipationPoolId(KENO.id, _))(breakOut)
+
+}

--- a/src/main/scala/domain/products/keno/KenoProductOrderFactory.scala
+++ b/src/main/scala/domain/products/keno/KenoProductOrderFactory.scala
@@ -1,0 +1,20 @@
+package domain.products.keno
+
+import domain.PoolResourceProvider.ProductOrderFactoryAI
+import play.api.libs.json.JsObject
+
+class KenoProductOrderFactory extends ProductOrderFactoryAI[KenoBet, KenoParticipationPools, KenoGamingProductOrder]{
+
+  protected def parseBets(bets: Seq[JsObject]): Seq[KenoBet] = bets.map { bet => KenoBet(
+    numbers = (bet \ "numbers").as[Seq[Int]], stake = (bet \ "stake").as[Int]
+  )}
+
+  protected def parseParticipationPools(pools: JsObject): KenoParticipationPools = fromIntermediateSingleDayPoolsData(pools) { data =>
+    KenoParticipationPools(data.firstDate, data.drawCount)
+  }
+
+  override protected def createOrder(bets: Seq[KenoBet], pools: KenoParticipationPools, variant: Option[String], json: JsObject): KenoGamingProductOrder = {
+    KenoGamingProductOrder(bets, pools, variant, json)
+  }
+
+}

--- a/src/main/scala/domain/products/mmls/MmlsGamingProductOrder.scala
+++ b/src/main/scala/domain/products/mmls/MmlsGamingProductOrder.scala
@@ -1,0 +1,47 @@
+package domain.products.mmls
+
+import java.net.URI
+import java.time.{DayOfWeek, LocalDate}
+
+import domain.products.GamingProduct.gamingProductIdToURI
+import domain.products.ML24GamingProduct.MMLS
+import domain.products.ParticipationPools.{ParticipationPoolId, formatParticipationPoolId}
+import domain.products.{Bet, GamingProductOrder, ParticipationPools}
+import play.api.libs.json.JsObject
+
+import scala.collection.breakOut
+
+
+case class MmlsGamingProductOrder(
+  bets: Seq[MmlsBet],
+  participationPools: MmlsParticipationPools,
+  variant: Option[String] = None,
+  json: JsObject
+) extends GamingProductOrder {
+  override def productURI: URI = MmlsGamingProductOrder.productURI
+
+  override def withEmptyJson(): MmlsGamingProductOrder = copy(json = JsObject(Seq.empty))
+}
+
+object MmlsGamingProductOrder {
+  val productURI: URI = gamingProductIdToURI(MMLS.id)
+}
+
+case class MmlsBet(numbers: Seq[Int], megaBall: Int) extends Bet
+
+case class MmlsParticipationPools(
+  firstDate: LocalDate,
+  drawDays: Set[DayOfWeek],
+  drawCount: Int
+) extends ParticipationPools {
+
+  def drawDates: Seq[LocalDate] = {
+    Iterator.iterate(firstDate)(_.plusDays(1))
+      .filter(drawDate => drawDays(drawDate.getDayOfWeek))
+      .take(drawCount)
+      .toVector
+  }
+
+  override def ids: Set[ParticipationPoolId] = drawDates.map(formatParticipationPoolId(MMLS.id, _))(breakOut)
+
+}

--- a/src/main/scala/domain/products/mmls/MmlsProductOrderFactory.scala
+++ b/src/main/scala/domain/products/mmls/MmlsProductOrderFactory.scala
@@ -1,0 +1,20 @@
+package domain.products.mmls
+
+import domain.PoolResourceProvider.ProductOrderFactoryAI
+import play.api.libs.json.JsObject
+
+class MmlsProductOrderFactory extends ProductOrderFactoryAI[MmlsBet, MmlsParticipationPools, MmlsGamingProductOrder]{
+
+  protected def parseBets(bets: Seq[JsObject]): Seq[MmlsBet] = bets.map { bet => MmlsBet(
+    numbers = (bet \ "numbers").as[Seq[Int]], megaBall = (bet \ "mega-ball").as[Int]
+  )}
+
+  protected def parseParticipationPools(pools: JsObject): MmlsParticipationPools = fromIntermediateMultiDayPoolsData(pools) { data =>
+    MmlsParticipationPools(data.firstDate, data.drawDays, data.drawCount)
+  }
+
+  override protected def createOrder(bets: Seq[MmlsBet], pools: MmlsParticipationPools, variant: Option[String], json: JsObject): MmlsGamingProductOrder = {
+    MmlsGamingProductOrder(bets, pools, variant, json)
+  }
+
+}

--- a/src/main/scala/domain/products/uspbls/UspblsGamingProductOrder.scala
+++ b/src/main/scala/domain/products/uspbls/UspblsGamingProductOrder.scala
@@ -1,0 +1,47 @@
+package domain.products.uspbls
+
+import java.net.URI
+import java.time.{DayOfWeek, LocalDate}
+
+import domain.products.GamingProduct.gamingProductIdToURI
+import domain.products.ML24GamingProduct.USPBLS
+import domain.products.ParticipationPools.{ParticipationPoolId, formatParticipationPoolId}
+import domain.products.{Bet, GamingProductOrder, ParticipationPools}
+import play.api.libs.json.JsObject
+
+import scala.collection.breakOut
+
+
+case class UspblsGamingProductOrder(
+  bets: Seq[UspblsBet],
+  participationPools: UspblsParticipationPools,
+  variant: Option[String] = None,
+  json: JsObject
+) extends GamingProductOrder {
+  override def productURI: URI = UspblsGamingProductOrder.productURI
+
+  override def withEmptyJson(): UspblsGamingProductOrder = copy(json = JsObject(Seq.empty))
+}
+
+object UspblsGamingProductOrder {
+  val productURI: URI = gamingProductIdToURI(USPBLS.id)
+}
+
+case class UspblsBet(numbers: Seq[Int], powerBall: Int) extends Bet
+
+case class UspblsParticipationPools(
+  firstDate: LocalDate,
+  drawDays: Set[DayOfWeek],
+  drawCount: Int
+) extends ParticipationPools {
+
+  def drawDates: Seq[LocalDate] = {
+    Iterator.iterate(firstDate)(_.plusDays(1))
+      .filter(drawDate => drawDays(drawDate.getDayOfWeek))
+      .take(drawCount)
+      .toVector
+  }
+
+  override def ids: Set[ParticipationPoolId] = drawDates.map(formatParticipationPoolId(USPBLS.id, _))(breakOut)
+
+}

--- a/src/main/scala/domain/products/uspbls/UspblsProductOrderFactory.scala
+++ b/src/main/scala/domain/products/uspbls/UspblsProductOrderFactory.scala
@@ -1,0 +1,20 @@
+package domain.products.uspbls
+
+import domain.PoolResourceProvider.ProductOrderFactoryAI
+import play.api.libs.json.JsObject
+
+class UspblsProductOrderFactory extends ProductOrderFactoryAI[UspblsBet, UspblsParticipationPools, UspblsGamingProductOrder]{
+
+  protected def parseBets(bets: Seq[JsObject]): Seq[UspblsBet] = bets.map { bet => UspblsBet(
+    numbers = (bet \ "numbers").as[Seq[Int]], powerBall = (bet \ "power-ball").as[Int]
+  )}
+
+  protected def parseParticipationPools(pools: JsObject): UspblsParticipationPools = fromIntermediateMultiDayPoolsData(pools) { data =>
+    UspblsParticipationPools(data.firstDate, data.drawDays, data.drawCount)
+  }
+
+  override protected def createOrder(bets: Seq[UspblsBet], pools: UspblsParticipationPools, variant: Option[String], json: JsObject): UspblsGamingProductOrder = {
+    UspblsGamingProductOrder(bets, pools, variant, json)
+  }
+
+}

--- a/src/main/scala/model/ApplicationSettings.scala
+++ b/src/main/scala/model/ApplicationSettings.scala
@@ -9,6 +9,7 @@ import util.Utils.{ErrorMsg, UIValue}
 
 case class ApplicationSettings(credentialsSpecs: CredentialsConfig,
                                archiveExtractionTarget: UIValue[File],
+                               validatePoolOnLoading: Boolean,
                                showUIDebugControls: Boolean) {
 
   def errors: Seq[ErrorMsg] = archiveExtractionTarget.error.toSeq ++ credentialsSpecs.errors

--- a/src/main/scala/util/Utils.scala
+++ b/src/main/scala/util/Utils.scala
@@ -121,7 +121,8 @@ object Utils {
   def stringToOption(string:  String): Option[String] = if( (string == null) || string.isEmpty) None else Some(string)
 
   def dayOfWeekFromString(value: String) : Option[DayOfWeek] = {
-    dayOfWeekMap.get(value).orElse(dayOfWeekMap_full.get(value))
+    val valueUpperCase = value.toUpperCase
+    dayOfWeekMap.get(valueUpperCase).orElse(dayOfWeekMap_full.get(valueUpperCase))
   }
 
   def mkFailure[T](msg: String): Failure[T] = new Failure[T](new Exception(msg))

--- a/src/main/scala/view/OrderPane.scala
+++ b/src/main/scala/view/OrderPane.scala
@@ -2,16 +2,17 @@ package view
 
 
 import java.time.format.{DateTimeFormatter, FormatStyle}
+
 import javafx.beans.binding.Bindings
 import javafx.scene.control._
 import javafx.scene.layout._
-
 import domain.products.GamingProduct.gamingProductIdFromURI
 import domain.products.amls.{AmlsBet, AmlsGamingProductOrder, AmlsParticipationPools}
 import domain.products.aols.{AolsBet, AolsGamingProductOrder, AolsParticipationPools}
 import domain.products.apls.{AplsBet, AplsGamingProductOrder, AplsParticipationPools}
 import domain.products.asls.{AslsBet, AslsGamingProductOrder, AslsParticipationPools}
 import domain.products.awls.{AwlsBet, AwlsGamingProductOrder, AwlsParticipationPools}
+import domain.products.c4ls.{C4lsBet, C4lsGamingProductOrder, C4lsParticipationPools}
 import domain.products.ejs.{EjsBet, EjsGamingProductOrder, EjsParticipationPools}
 import domain.products.ems.{EmsBet, EmsGamingProductOrder, EmsParticipationPools}
 import domain.products.emsplus.{EmsPlusBet, EmsPlusGamingProductOrder, EmsPlusParticipationPools}
@@ -22,6 +23,8 @@ import domain.products.irishraffle.{IrishRaffleBet, IrishRaffleGamingProductOrde
 import domain.products.irls.p1.{IrlsP1GamingProductOrder, IrlsP1ParticipationPools}
 import domain.products.irls.p2.{IrlsP2GamingProductOrder, IrlsP2ParticipationPools}
 import domain.products.irls.{IrlsBet, IrlsGamingProductOrder, IrlsParticipationPools}
+import domain.products.keno.{KenoBet, KenoGamingProductOrder, KenoParticipationPools}
+import domain.products.mmls.{MmlsBet, MmlsGamingProductOrder, MmlsParticipationPools}
 import domain.products.pls.{PlsBet, PlsGamingProductOrder, PlsParticipationPools}
 import domain.products.plus5.{Plus5Bet, Plus5GamingProductOrder, Plus5ParticipationPools}
 import domain.products.s6.{S6Bet, S6GamingProductOrder, S6ParticipationPools}
@@ -29,6 +32,7 @@ import domain.products.s77.{S77Bet, S77GamingProductOrder, S77ParticipationPools
 import domain.products.sls.{SlsBet, SlsGamingProductOrder, SlsParticipationPools}
 import domain.products.ukls.{UklsBet, UklsGamingProductOrder, UklsParticipationPools}
 import domain.products.uktbls.{UktblsBet, UktblsGamingProductOrder, UktblsParticipationPools}
+import domain.products.uspbls.{UspblsBet, UspblsGamingProductOrder, UspblsParticipationPools}
 import domain.products.xmasl.{XmaslBet, XmaslGamingProductOrder, XmaslParticipationPools}
 import domain.products.{Bet, GamingProductOrder, ParticipationPools, ParticipationPoolsMultiplyDays}
 import play.api.libs.json.Json
@@ -223,6 +227,14 @@ object OrderPaneFactory {
         Seq(BetNumbersSpec(name = "Numbers", cssClass = "numbers", _.numbers)), productCssClass = "awls"
       )
     },
+    classOf[C4lsGamingProductOrder] -> { () => 
+      new GenericOrderPane[C4lsGamingProductOrder, C4lsParticipationPools, C4lsBet](
+        Seq(
+          BetNumbersSpec(name = "Numbers", cssClass = "numbers", _.numbers),
+          BetNumbersSpec(name = "Cashball", cssClass = "extranumbers", x => Seq(x.cashBall))
+        ), productCssClass = "c4ls"
+      )
+    },    
     classOf[EjsGamingProductOrder] -> { () =>
       new GenericOrderPane[EjsGamingProductOrder, EjsParticipationPools, EjsBet](
         Seq(
@@ -282,6 +294,22 @@ object OrderPaneFactory {
         Seq(BetNumbersSpec(name="Numbers", cssClass="numbers", _.numbers)), productCssClass = "irls_p2"
       )
     },
+    classOf[KenoGamingProductOrder] -> { () =>
+      new GenericOrderPane[KenoGamingProductOrder, KenoParticipationPools, KenoBet](
+        Seq(
+          BetNumbersSpec(name="Numbers", cssClass="numbers", _.numbers),
+          BetNumbersSpec(name="Stake", cssClass="extranumbers", x => Seq(x.stake))
+        ), productCssClass = "keno"
+      )
+    },    
+    classOf[MmlsGamingProductOrder] -> { () =>
+      new GenericOrderPane[MmlsGamingProductOrder, MmlsParticipationPools, MmlsBet](
+        Seq(
+          BetNumbersSpec(name="Numbers", cssClass="numbers", _.numbers),
+          BetNumbersSpec(name="Megaball", cssClass="extranumbers", x => Seq(x.megaBall))
+        ), productCssClass = "mmls"
+      )
+    },    
     classOf[PlsGamingProductOrder] -> { () =>
       new GenericOrderPane[PlsGamingProductOrder, PlsParticipationPools, PlsBet](
         Seq(BetNumbersSpec(name="Numbers", cssClass="numbers", _.numbers)), productCssClass = "pls"
@@ -318,6 +346,14 @@ object OrderPaneFactory {
           BetNumbersSpec(name = "Numbers", cssClass = "numbers", _.numbers),
           BetNumbersSpec(name = "Thunderball", cssClass = "extranumbers", x => Seq(x.thunderball))
         ), productCssClass = "uktbls"
+      )
+    },
+    classOf[UspblsGamingProductOrder] -> { () =>
+      new GenericOrderPane[UspblsGamingProductOrder, UspblsParticipationPools, UspblsBet](
+        Seq(
+          BetNumbersSpec(name = "Numbers", cssClass = "numbers", _.numbers),
+          BetNumbersSpec(name = "Powerball", cssClass = "extranumbers", x => Seq(x.powerBall))
+        ), productCssClass = "uspbls"
       )
     },
     classOf[XmaslGamingProductOrder] -> { () =>

--- a/src/main/scala/view/SettingsDialogView.scala
+++ b/src/main/scala/view/SettingsDialogView.scala
@@ -2,27 +2,24 @@ package view
 
 import java.io.File
 import java.util.Comparator
+
 import javafx.collections.FXCollections
 import javafx.collections.transformation.SortedList
 import javafx.scene.control._
 import javafx.scene.layout._
 import javafx.stage.FileChooser.ExtensionFilter
 import javafx.util.Callback
-
-import util.Utils
-import Utils.UIValue
 import model.ApplicationSettings
 import model.ApplicationSettings._
 import org.slf4j.LoggerFactory
+import scalafx.Includes._
 import util.Utils
+import util.Utils.{UIValue, stringToOption}
 import view.CssClass.Color
 import view.JfxImplicits._
 import view.PublicKeyEditor.PublicKeyListItem
 import view.impl.StructureElements.{SectionSeparator, VSpacer}
 import view.impl.{ChooseViaDialog, ValidationErrorHint}
-import Utils.stringToOption
-
-import scalafx.Includes._
 
 
 /**

--- a/src/main/scala/view/SettingsDialogView.scala
+++ b/src/main/scala/view/SettingsDialogView.scala
@@ -38,6 +38,8 @@ class SettingsDialogView(private var initialSettings: ApplicationSettings) exten
   private val tefArchiveExtractionDir = new TextField()
   private val validationHint_tefArchiveExtractionDir = new ValidationErrorHint
 
+  private val cbStartValidationAfterLoading = new CheckBox()
+  
   private val btnChooseFile_caCert = new Button("File")
   private val btnChooseFile_archiveExtractionDir = new Button("File")
 
@@ -98,6 +100,11 @@ class SettingsDialogView(private var initialSettings: ApplicationSettings) exten
       rowInd += 1
 
       gridGlobal.add(validationHint_tefArchiveExtractionDir, 1, rowInd)
+
+      rowInd += 1
+
+      gridGlobal.add(new Label("Start validation after loading:"), 0, rowInd)
+      gridGlobal.add(cbStartValidationAfterLoading, 1, rowInd)
     }
 
     // populate gridCerts
@@ -180,6 +187,8 @@ class SettingsDialogView(private var initialSettings: ApplicationSettings) exten
     tefArchiveExtractionDir.setText(settings.archiveExtractionTarget.value.map(_.toString).orNull)
     validationHint_tefArchiveExtractionDir.setError(settings.archiveExtractionTarget.error.map(_.message))
 
+    cbStartValidationAfterLoading.setSelected(settings.validatePoolOnLoading)
+    
     tefCaCertFile.setText(settings.credentialsSpecs.certConfigItems.headOption.flatMap(_.file.value.map(_.toString)).getOrElse(""))
     validationHint_caCertFile.setError(settings.credentialsSpecs.certConfigItems.headOption.flatMap(_.file.error.map(_.message)))
 
@@ -232,6 +241,10 @@ class SettingsDialogView(private var initialSettings: ApplicationSettings) exten
 
     tefArchiveExtractionDir.onAction = handle {
       onArchiveExtractionDirChanged(Utils.stringToOption(tefArchiveExtractionDir.getText).map(new File(_)))
+    }
+
+    cbStartValidationAfterLoading.onAction = handle {
+      initialSettings = initialSettings.copy(validatePoolOnLoading = cbStartValidationAfterLoading.isSelected)
     }
   }
 

--- a/src/test/resources/orderdocs/order/orderWithAllProducts.json
+++ b/src/test/resources/orderdocs/order/orderWithAllProducts.json
@@ -9,6 +9,20 @@
     "creation-date": "2017-02-05T13:22:47.123Z"
   },
   "gaming-product-orders": {
+    "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/c4ls": {
+      "bets": [{
+        "numbers": [1, 2, 3, 4, 5],
+        "cash-ball": 1
+      }, {
+        "numbers": [2, 3, 4, 5, 6],
+        "cash-ball": 2
+      }],
+      "participation-pools": {
+        "first-date": "2018-05-10",
+        "draw-count": 1,
+        "draw-days": ["THURSDAY"]
+      }
+    },
     "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/ejs": {
       "bets": [{
         "numbers": [1, 2, 3, 4, 5],
@@ -68,15 +82,6 @@
       }, {
         "numbers": [2, 4, 6, 29, 32],
         "starnumbers": [2, 10]
-      }, {
-        "numbers": [11, 12, 13, 14, 15],
-        "starnumbers": [1, 11]
-      }, {
-        "numbers": [12, 14, 16, 29, 32],
-        "starnumbers": [2, 10]
-      }, {
-        "numbers": [21, 22, 23, 24, 25],
-        "starnumbers": [1, 2]
       }],
       "participation-pools": {
         "first-date": "2017-02-07",
@@ -86,12 +91,6 @@
     },
     "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/emsp": {
       "bets": [{
-        "numbers": [1, 2, 3, 4, 5]
-      }, {
-        "numbers": [2, 4, 6, 29, 32]
-      }, {
-        "numbers": [11, 12, 13, 14, 15]
-      }, {
         "numbers": [12, 14, 16, 29, 32]
       }, {
         "numbers": [21, 22, 23, 24, 25]
@@ -155,6 +154,33 @@
         "draw-days": ["WEDNESDAY"]
       }
     },
+    "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/keno": {
+      "bets": [{
+        "numbers": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "stake": 1
+      }],
+      "participation-pools": {
+        "first-date": "2018-05-08",
+        "draw-count": 1
+      }
+    },
+    "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/mmls": {
+      "bets": [{
+        "numbers": [1, 2, 3, 4, 5],
+        "mega-ball": 1
+      }, {
+        "numbers": [6, 7, 8, 9, 10],
+        "mega-ball": 2
+      }, {
+        "numbers": [11, 12, 13, 14, 15],
+        "mega-ball": 3
+      }],
+      "participation-pools": {
+        "first-date": "2018-05-08",
+        "draw-count": 1,
+        "draw-days": ["TUESDAY"]
+      }
+    },
     "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/ukls": {
       "bets": [{
         "numbers": [8, 1, 9, 2, 7, 4]
@@ -175,6 +201,20 @@
       }],
       "participation-pools": {
         "first-date": "2017-02-08",
+        "draw-count": 1,
+        "draw-days": ["WEDNESDAY"]
+      }
+    },
+    "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/uspbls": {
+      "bets": [{
+        "numbers": [1, 2, 3, 4, 5],
+        "power-ball": 1
+      }, {
+        "numbers": [6, 7, 8, 9, 10],
+        "power-ball": 2
+      }],
+      "participation-pools": {
+        "first-date": "2018-05-09",
         "draw-count": 1,
         "draw-days": ["WEDNESDAY"]
       }

--- a/src/test/scala/domain/PoolResourceProviderSpec.scala
+++ b/src/test/scala/domain/PoolResourceProviderSpec.scala
@@ -153,22 +153,19 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       withClue("order.gamingProductOrders.size")(o.gamingProductOrders.size shouldEqual ML24GamingProduct.values.size)
 
       checkProductOrder[AmlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AMLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(AmlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)), AmlsBet(numbers = Seq(2, 3, 4, 5, 6, 7)))
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(AmlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)))
         productOrder.participationPools shouldBe AmlsParticipationPools(firstDate = LocalDate.of(2017, 2, 13), drawCount = 1)
       }
 
       checkProductOrder[AolsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AOLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(
-          AolsBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7)),
-          AolsBet(numbers = Seq(2, 3, 4, 5, 6, 7, 8))
-        )
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(AolsBet(numbers = Seq(2, 3, 4, 5, 6, 7, 8)))
         productOrder.participationPools shouldBe AolsParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawCount = 1)
       }
 
       checkProductOrder[AplsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(APLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           AplsBet(numbers = Seq(1, 2, 3, 4, 5, 6), powerball = 2),
           AplsBet(numbers = Seq(2, 3, 4, 5, 6, 7), powerball = 3)
@@ -177,7 +174,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
       
       checkProductOrder[AslsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(ASLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           AslsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
           AslsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
@@ -186,11 +183,8 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[AwlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AWLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(
-          AwlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
-          AwlsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
-        )
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(AwlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)))
         productOrder.participationPools shouldBe AwlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawCount = 1)
       }
 
@@ -204,7 +198,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[EmsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EMS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           EmsBet(numbers=Seq(1, 2, 3, 4, 5), starnumbers = Seq(1, 11)),
           EmsBet(numbers=Seq(2, 4, 6, 29, 32), starnumbers = Seq(2, 10))
@@ -213,16 +207,16 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
       
       checkProductOrder[EmsPlusGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EMSPLUS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
-          EmsPlusBet(numbers = Seq(12, 14, 16, 29, 32)),
-          EmsPlusBet(numbers = Seq(21, 22, 23, 24, 25))
+          EmsPlusBet(numbers = Seq(1, 2, 3, 4, 5)),
+          EmsPlusBet(numbers = Seq(2, 4, 6, 29, 32))
         )
         productOrder.participationPools shouldBe EmsPlusParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawDays = Set(TUESDAY), drawCount = 1)
       }
 
       checkProductOrder[EjsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EJS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           EjsBet(numbers = Seq(1, 2, 3, 4, 5), euroNumbers = Seq(1, 8)),
           EjsBet(numbers = Seq(2, 4, 6, 29, 32), euroNumbers = Seq(4, 5))
@@ -231,7 +225,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[FlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(FLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           FlsBet(numbers = Seq(1, 2, 3, 4, 5), chancenumber = 2),
           FlsBet(numbers = Seq(2, 3, 4, 5, 6), chancenumber = 3)
@@ -240,7 +234,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[GlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(GLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           GlsBet(numbers = Seq(1, 2, 3, 4, 5, 6), supernumber = 7, system = None),
           GlsBet(numbers = Seq(1, 2, 4, 6, 29, 32, 49), supernumber = 0, system = Some("full"))
@@ -249,7 +243,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[GlsSGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(GLSS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           GlsSBet(numbers = Seq(8, 1, 9, 2, 9, 4, 7)),
           GlsSBet(numbers = Seq(2, 5, 0, 7, 0, 8, 6))
@@ -258,19 +252,19 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[IrlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
         productOrder.participationPools shouldBe IrlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
       }
 
       checkProductOrder[IrlsP1GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLSP1.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
         productOrder.participationPools shouldBe IrlsP1ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
       }
 
       checkProductOrder[IrlsP2GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLSP2.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4))
         )
@@ -278,7 +272,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[IrishRaffleGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRISHRAFFLE.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           IrishRaffleBet(numbers = Seq(1, 2, 3, 4)),
           IrishRaffleBet(numbers = Seq(0, 4, 6, 9))
@@ -305,16 +299,13 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[PlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(PLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(
-          PlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
-          PlsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
-        )
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(PlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)))
         productOrder.participationPools shouldBe PlsParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawDays = Set(TUESDAY), drawCount = 1)
       }
 
       checkProductOrder[Plus5GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(PLUS5.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           Plus5Bet(numbers = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9)),
           Plus5Bet(numbers = Seq(2, 3, 4, 5, 6, 7, 8, 9, 10))
@@ -323,7 +314,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[S6GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(S6.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           S6Bet(numbers = Seq(0, 8, 1, 8, 3, 6)),
           S6Bet(numbers = Seq(3, 6, 2, 8, 1, 9))
@@ -332,7 +323,7 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[S77GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(S77.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           S77Bet(numbers = Seq(7, 0, 8, 1, 8, 3, 6)),
           S77Bet(numbers = Seq(3, 6, 1, 8, 1, 9, 7))
@@ -341,19 +332,19 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
       
       checkProductOrder[SlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(SLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(SlsBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7)), SlsBet(numbers = Seq(2, 3, 4, 5, 6, 7, 8)))
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(SlsBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7)))
         productOrder.participationPools shouldBe SlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
       }
 
       checkProductOrder[UklsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(UKLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(UklsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
         productOrder.participationPools shouldBe UklsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
       }
 
       checkProductOrder[UktblsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(UKTBLS.id))){ productOrder =>
-        productOrder.variant shouldBe None
+        productOrder.variant shouldBe Some("variant_1")
         productOrder.bets shouldBe Seq(
           UktblsBet(numbers = Seq(1, 2, 3, 4, 5), thunderball = 10),
           UktblsBet(numbers = Seq(6, 7, 8, 9, 10), thunderball = 11)
@@ -368,8 +359,8 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       }
 
       checkProductOrder[XmaslGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(XMASL.id))){ productOrder =>
-        productOrder.variant shouldBe None
-        productOrder.bets shouldBe Seq(XmaslBet(numbers = Seq(1, 2, 3, 4, 5)), XmaslBet(numbers = Seq(0, 4, 6, 5, 9)))
+        productOrder.variant shouldBe Some("variant_1")
+        productOrder.bets shouldBe Seq(XmaslBet(numbers = Seq(1, 2, 3, 4, 5)))
         productOrder.participationPools shouldBe XmaslParticipationPools(firstDate = LocalDate.of(2017, 12, 22))
       }
     }

--- a/src/test/scala/domain/PoolResourceProviderSpec.scala
+++ b/src/test/scala/domain/PoolResourceProviderSpec.scala
@@ -4,26 +4,56 @@ import java.io.{ByteArrayInputStream, File, InputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Path, Paths}
+import java.time.DayOfWeek._
+import java.time._
 import java.time.format.DateTimeParseException
-import java.time.{LocalDate, LocalTime, ZoneOffset, ZonedDateTime}
 
 import domain.OrderMetadata.{DrawHedgingData, OrderHedgingData}
 import domain.PoolResource.Filenames
-import domain.products.GamingProduct.GamingProductId
-import domain.products.ML24GamingProduct
+import domain.products.GamingProduct.{GamingProductId, gamingProductIdToURI}
+import domain.products.ML24GamingProduct._
+import domain.products.amls.{AmlsBet, AmlsGamingProductOrder, AmlsParticipationPools}
+import domain.products.aols.{AolsBet, AolsGamingProductOrder, AolsParticipationPools}
+import domain.products.apls.{AplsBet, AplsGamingProductOrder, AplsParticipationPools}
+import domain.products.asls.{AslsBet, AslsGamingProductOrder, AslsParticipationPools}
+import domain.products.awls.{AwlsBet, AwlsGamingProductOrder, AwlsParticipationPools}
+import domain.products.c4ls.{C4lsBet, C4lsGamingProductOrder, C4lsParticipationPools}
 import domain.products.ejs.{EjsBet, EjsGamingProductOrder, EjsParticipationPools}
+import domain.products.ems.{EmsBet, EmsGamingProductOrder, EmsParticipationPools}
+import domain.products.emsplus.{EmsPlusBet, EmsPlusGamingProductOrder, EmsPlusParticipationPools}
+import domain.products.fls.{FlsBet, FlsGamingProductOrder, FlsParticipationPools}
+import domain.products.gls.{GlsBet, GlsGamingProductOrder, GlsParticipationPools}
+import domain.products.glss.{GlsSBet, GlsSGamingProductOrder, GlsSParticipationPools}
+import domain.products.irishraffle.{IrishRaffleBet, IrishRaffleGamingProductOrder, IrishRaffleParticipationPools}
+import domain.products.irls.p1.{IrlsP1GamingProductOrder, IrlsP1ParticipationPools}
+import domain.products.irls.p2.{IrlsP2GamingProductOrder, IrlsP2ParticipationPools}
+import domain.products.irls.{IrlsBet, IrlsGamingProductOrder, IrlsParticipationPools}
+import domain.products.keno.{KenoBet, KenoGamingProductOrder, KenoParticipationPools}
+import domain.products.mmls.{MmlsBet, MmlsGamingProductOrder, MmlsParticipationPools}
+import domain.products.pls.{PlsBet, PlsGamingProductOrder, PlsParticipationPools}
+import domain.products.plus5.{Plus5Bet, Plus5GamingProductOrder, Plus5ParticipationPools}
+import domain.products.s6.{S6Bet, S6GamingProductOrder, S6ParticipationPools}
+import domain.products.s77.{S77Bet, S77GamingProductOrder, S77ParticipationPools}
+import domain.products.sls.{SlsBet, SlsGamingProductOrder, SlsParticipationPools}
+import domain.products.ukls.{UklsBet, UklsGamingProductOrder, UklsParticipationPools}
+import domain.products.uktbls.{UktblsBet, UktblsGamingProductOrder, UktblsParticipationPools}
+import domain.products.uspbls.{UspblsBet, UspblsGamingProductOrder, UspblsParticipationPools}
+import domain.products.xmasl.{XmaslBet, XmaslGamingProductOrder, XmaslParticipationPools}
+import domain.products.{GamingProductOrder, ML24GamingProduct}
 import org.scalatest.{FeatureSpec, Matchers}
 import play.api.libs.json.Json
 import util.Utils
 import util.Utils.fileInputStreamOf
 
+import scala.reflect.{ClassTag, classTag}
 import scala.util.{Failure, Success, Try}
 
 
 class PoolResourceProviderSpec extends FeatureSpec with Matchers {
 
-  val workingDir = new File(System.getProperty("user.dir"))
-
+  private val workingDir = new File(System.getProperty("user.dir"))
+  private val dummyPath = new File("some/dummyFile").toPath
+  
   feature("Read pool archive metadata") {
 
     val metadataFile = new File(workingDir, "src/test/resources/validorders/metadata.json")
@@ -115,14 +145,274 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
         val productIdsInOrder: Set[GamingProductId] = o.gamingProductOrders.keys.map{uri =>
           domain.products.GamingProduct.gamingProductIdFromURI(uri)
         }.toSet
-        val allProductIds = ML24GamingProduct.All.map(_.id).toSet
+        val allProductIds = ML24GamingProduct.values.map(_.id).toSet
         withClue(s"order.gamingProductOrders difference: ${ allProductIds diff productIdsInOrder}"){
           productIdsInOrder shouldEqual allProductIds 
         }
       }
-      withClue("order.gamingProductOrders.size")(o.gamingProductOrders.size shouldEqual ML24GamingProduct.All.size)
+      withClue("order.gamingProductOrders.size")(o.gamingProductOrders.size shouldEqual ML24GamingProduct.values.size)
+
+      checkProductOrder[AmlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AMLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(AmlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)), AmlsBet(numbers = Seq(2, 3, 4, 5, 6, 7)))
+        productOrder.participationPools shouldBe AmlsParticipationPools(firstDate = LocalDate.of(2017, 2, 13), drawCount = 1)
+      }
+
+      checkProductOrder[AolsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AOLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          AolsBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7)),
+          AolsBet(numbers = Seq(2, 3, 4, 5, 6, 7, 8))
+        )
+        productOrder.participationPools shouldBe AolsParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawCount = 1)
+      }
+
+      checkProductOrder[AplsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(APLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          AplsBet(numbers = Seq(1, 2, 3, 4, 5, 6), powerball = 2),
+          AplsBet(numbers = Seq(2, 3, 4, 5, 6, 7), powerball = 3)
+        )
+        productOrder.participationPools shouldBe AplsParticipationPools(firstDate = LocalDate.of(2017, 2, 9), drawCount = 1)
+      }
+      
+      checkProductOrder[AslsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(ASLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          AslsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
+          AslsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
+        )
+        productOrder.participationPools shouldBe AslsParticipationPools(firstDate = LocalDate.of(2017, 2, 11), drawCount = 1)
+      }
+
+      checkProductOrder[AwlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(AWLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          AwlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
+          AwlsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
+        )
+        productOrder.participationPools shouldBe AwlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawCount = 1)
+      }
+
+      checkProductOrder[C4lsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(C4LS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          C4lsBet(numbers = Seq(1, 2, 3, 4, 5), cashBall = 1),
+          C4lsBet(numbers = Seq(2, 3, 4, 5, 6), cashBall = 2)
+        )
+        productOrder.participationPools shouldBe C4lsParticipationPools(firstDate = LocalDate.of(2018, 5, 10), drawDays = Set(THURSDAY), drawCount = 1)
+      }
+
+      checkProductOrder[EmsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EMS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          EmsBet(numbers=Seq(1, 2, 3, 4, 5), starnumbers = Seq(1, 11)),
+          EmsBet(numbers=Seq(2, 4, 6, 29, 32), starnumbers = Seq(2, 10))
+        )
+        productOrder.participationPools shouldBe EmsParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawDays = Set(TUESDAY), drawCount = 1)
+      }
+      
+      checkProductOrder[EmsPlusGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EMSPLUS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          EmsPlusBet(numbers = Seq(12, 14, 16, 29, 32)),
+          EmsPlusBet(numbers = Seq(21, 22, 23, 24, 25))
+        )
+        productOrder.participationPools shouldBe EmsPlusParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawDays = Set(TUESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[EjsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(EJS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          EjsBet(numbers = Seq(1, 2, 3, 4, 5), euroNumbers = Seq(1, 8)),
+          EjsBet(numbers = Seq(2, 4, 6, 29, 32), euroNumbers = Seq(4, 5))
+        )
+        productOrder.participationPools shouldBe EjsParticipationPools(firstDate = LocalDate.of(2017, 2, 10), drawCount = 1)
+      }
+
+      checkProductOrder[FlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(FLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          FlsBet(numbers = Seq(1, 2, 3, 4, 5), chancenumber = 2),
+          FlsBet(numbers = Seq(2, 3, 4, 5, 6), chancenumber = 3)
+        )
+        productOrder.participationPools shouldBe FlsParticipationPools(firstDate = LocalDate.of(2017, 2, 6), drawDays = Set(MONDAY), drawCount = 1)
+      }
+
+      checkProductOrder[GlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(GLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          GlsBet(numbers = Seq(1, 2, 3, 4, 5, 6), supernumber = 7, system = None),
+          GlsBet(numbers = Seq(1, 2, 4, 6, 29, 32, 49), supernumber = 0, system = Some("full"))
+        )
+        productOrder.participationPools shouldBe GlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[GlsSGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(GLSS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          GlsSBet(numbers = Seq(8, 1, 9, 2, 9, 4, 7)),
+          GlsSBet(numbers = Seq(2, 5, 0, 7, 0, 8, 6))
+        )
+        productOrder.participationPools shouldBe GlsSParticipationPools(firstDate = LocalDate.of(2017, 2, 11), drawCount = 1)
+      }
+
+      checkProductOrder[IrlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
+        productOrder.participationPools shouldBe IrlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[IrlsP1GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLSP1.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
+        productOrder.participationPools shouldBe IrlsP1ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[IrlsP2GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRLSP2.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          IrlsBet(numbers = Seq(8, 1, 9, 2, 7, 4))
+        )
+        productOrder.participationPools shouldBe IrlsP2ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[IrishRaffleGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(IRISHRAFFLE.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          IrishRaffleBet(numbers = Seq(1, 2, 3, 4)),
+          IrishRaffleBet(numbers = Seq(0, 4, 6, 9))
+        )
+        productOrder.participationPools shouldBe IrishRaffleParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[KenoGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(KENO.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          KenoBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), stake=1)
+        )
+        productOrder.participationPools shouldBe KenoParticipationPools(firstDate = LocalDate.of(2018, 5, 8), drawCount = 1)
+      }
+
+      checkProductOrder[MmlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(MMLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          MmlsBet(numbers = Seq(1, 2, 3, 4, 5), megaBall = 1),
+          MmlsBet(numbers = Seq(6, 7, 8, 9, 10), megaBall = 2),
+          MmlsBet(numbers = Seq(11, 12, 13, 14, 15), megaBall = 3)
+        )
+        productOrder.participationPools shouldBe MmlsParticipationPools(firstDate = LocalDate.of(2018, 5, 8), drawDays = Set(TUESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[PlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(PLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          PlsBet(numbers = Seq(1, 2, 3, 4, 5, 6)),
+          PlsBet(numbers = Seq(2, 3, 4, 5, 6, 7))
+        )
+        productOrder.participationPools shouldBe PlsParticipationPools(firstDate = LocalDate.of(2017, 2, 7), drawDays = Set(TUESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[Plus5GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(PLUS5.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          Plus5Bet(numbers = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9)),
+          Plus5Bet(numbers = Seq(2, 3, 4, 5, 6, 7, 8, 9, 10))
+        )
+        productOrder.participationPools shouldBe Plus5ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawCount = 1)
+      }
+
+      checkProductOrder[S6GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(S6.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          S6Bet(numbers = Seq(0, 8, 1, 8, 3, 6)),
+          S6Bet(numbers = Seq(3, 6, 2, 8, 1, 9))
+        )
+        productOrder.participationPools shouldBe S6ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[S77GamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(S77.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          S77Bet(numbers = Seq(7, 0, 8, 1, 8, 3, 6)),
+          S77Bet(numbers = Seq(3, 6, 1, 8, 1, 9, 7))
+        )
+        productOrder.participationPools shouldBe S77ParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+      
+      checkProductOrder[SlsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(SLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(SlsBet(numbers = Seq(1, 2, 3, 4, 5, 6, 7)), SlsBet(numbers = Seq(2, 3, 4, 5, 6, 7, 8)))
+        productOrder.participationPools shouldBe SlsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[UklsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(UKLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(UklsBet(numbers = Seq(8, 1, 9, 2, 7, 4)))
+        productOrder.participationPools shouldBe UklsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[UktblsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(UKTBLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(
+          UktblsBet(numbers = Seq(1, 2, 3, 4, 5), thunderball = 10),
+          UktblsBet(numbers = Seq(6, 7, 8, 9, 10), thunderball = 11)
+        )
+        productOrder.participationPools shouldBe UktblsParticipationPools(firstDate = LocalDate.of(2017, 2, 8), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[UspblsGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(USPBLS.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(UspblsBet(numbers = Seq(1, 2, 3, 4, 5), powerBall = 1), UspblsBet(numbers = Seq(6, 7, 8, 9, 10), powerBall = 2))
+        productOrder.participationPools shouldBe UspblsParticipationPools(firstDate = LocalDate.of(2018, 5, 9), drawDays = Set(WEDNESDAY), drawCount = 1)
+      }
+
+      checkProductOrder[XmaslGamingProductOrder](o.gamingProductOrders(gamingProductIdToURI(XMASL.id))){ productOrder =>
+        productOrder.variant shouldBe None
+        productOrder.bets shouldBe Seq(XmaslBet(numbers = Seq(1, 2, 3, 4, 5)), XmaslBet(numbers = Seq(0, 4, 6, 5, 9)))
+        productOrder.participationPools shouldBe XmaslParticipationPools(firstDate = LocalDate.of(2017, 12, 22))
+      }
     }
 
+    scenario("'participation-pools' with different 'draw-days' notations") {
+      def testWithDrawDay(drawDayStr: String, expectedDrawDay: DayOfWeek): Unit = {
+        val orderJsonStr =
+          s"""
+             |{
+             |  "metadata": {
+             |    "retailer": {
+             |      "href": "http://zoe.mylotto24.co.uk/entities/mylotto24"
+             |    },
+             |    "origin": "tipp24.com",
+             |    "retail-customer": "ff97acdb-d79a-4f8b-b6ae-8ada63d9ea38",
+             |    "retailer-order-reference": "8e0c2944-6303-4ed2-8342-2f3bbfe921bd",
+             |    "creation-date": "2017-02-05T13:22:47.123Z"
+             |  },
+             |  "gaming-product-orders": {
+             |    "http://zoe.mylotto24.co.uk/gaming-products/mylotto24/gls": {
+             |      "bets": [{
+             |        "numbers": [1, 2, 3, 4, 5, 6],
+             |        "super-number": 7
+             |      }],
+             |      "participation-pools": {
+             |        "first-date": "2017-02-08",
+             |        "draw-days": ["$drawDayStr"],
+             |        "draw-count": 1
+             |      }
+             |    }
+             |  } 
+             |}
+          """.stripMargin
+        val provider = new PoolResourceProviderImpl
+        val o: Order = provider.parseOrder(orderJsonStr.getBytes.toIndexedSeq, dummyPath).get //TODO sollte Try[] returnen..
+        o.gamingProductOrders.head._2.participationPools.asInstanceOf[GlsParticipationPools].drawDays shouldBe Set(expectedDrawDay)
+      }
+
+      testWithDrawDay("WED", DayOfWeek.WEDNESDAY)
+      testWithDrawDay("wed", DayOfWeek.WEDNESDAY)
+      testWithDrawDay("WEDNESDAY", DayOfWeek.WEDNESDAY)
+      testWithDrawDay("Wednesday", DayOfWeek.WEDNESDAY)
+    }
   }
 
   feature("Parsing of an order.result") {
@@ -209,4 +499,11 @@ class PoolResourceProviderSpec extends FeatureSpec with Matchers {
       r.isFailure shouldEqual true
     }
   }
+
+  private def checkProductOrder[T <: GamingProductOrder : ClassTag](order: GamingProductOrder)(f: T => Unit): Unit = {
+    withClue(s"check ${classTag[T].runtimeClass.getSimpleName}:$order") {
+      f(order.asInstanceOf[T])
+    }
+  }
+
 }

--- a/src/test/scala/model/ApplicationModelSpec.scala
+++ b/src/test/scala/model/ApplicationModelSpec.scala
@@ -1355,6 +1355,7 @@ object ApplicatonModelTestSetup {
   val defaultSettings: ApplicationSettings = ApplicationSettings(
     defaultCredentialsSpecs,
     archiveExtractionTarget = defaultOrderExtractionTarget,
+    validatePoolOnLoading = false,
     showUIDebugControls = false)
 
   val defaultArchiveFile: File = new File(new File(System.getProperty("user.dir")),


### PR DESCRIPTION
- added support for products C4ls, Keno, Mmls and Uspbls
- added validate-pool-archive-after loading option
- introduced enumeratum enum for `PrimaryLottery` and `ML24GamingProduct`
- made `Utils.dayOfWeekFromString()` more robust for different notations
- amended unit tests
